### PR TITLE
custom protocol implementation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -139,12 +139,15 @@ Default: "illumina"
 --protocol [one protocol listed in the table below]
 ```
 
-| Protocol      | Library Prep Kit                        | Trimming Parameter                   | 3' Adapter Sequence   |
-| :------------ | :-------------------------------------- | :----------------------------------- | :-------------------  |
-| illumina      | Illumina TruSeq Small RNA               | clip_R1 = 0; three_prime_clip_R1 = 0 | TGGAATTCTCGGGTGCCAAGG |
-| nextflex      | BIOO SCIENTIFIC  NEXTFLEX Small RNA-Seq | clip_R1 = 4; three_prime_clip_R1 = 4 | TGGAATTCTCGGGTGCCAAGG |
-| qiaseq        | QIAGEN QIAseq miRNA                     | clip_R1 = 0; three_prime_clip_R1 = 0 | AACTGTAGGCACCATCAAT   |
-| cats          | Diagenode CATS Small RNA-seq            | clip_R1 = 3; three_prime_clip_R1 = 0 | GATCGGAAGAGCACACGTCTG |
+| Protocol           | Library Prep Kit                        | Trimming Parameter                   | 3' Adapter Sequence   |
+| :----------------- | :-------------------------------------- | :----------------------------------- | :-------------------  |
+| illumina           | Illumina TruSeq Small RNA               | clip_R1 = 0; three_prime_clip_R1 = 0 | TGGAATTCTCGGGTGCCAAGG |
+| nextflex           | BIOO SCIENTIFIC  NEXTFLEX Small RNA-Seq | clip_R1 = 4; three_prime_clip_R1 = 4 | TGGAATTCTCGGGTGCCAAGG |
+| qiaseq             | QIAGEN QIAseq miRNA                     | clip_R1 = 0; three_prime_clip_R1 = 0 | AACTGTAGGCACCATCAAT   |
+| cats               | Diagenode CATS Small RNA-seq            | clip_R1 = 3; three_prime_clip_R1 = 0 | GATCGGAAGAGCACACGTCTG |
+| custom<sup>*</sup> | user defined                            | user defined                         | user defined          |
+
+<sup>*</sup>**Note:** when running `--protocol custom` the user must define the 3' Adapter Sequence. If trimming parameters aren't provided the pipeline will deafult to clip_R1 = 0 and three_prime_clip_R1 = 0 (i.e. no extra clipping).
 
 ## Reference genomes
 

--- a/main.nf
+++ b/main.nf
@@ -711,6 +711,7 @@ process mirtrace {
 
      script:
      primer = (protocol=="cats") ? " " : " --adapter $three_prime_adapter "
+     protocol_opt = (protocol=="custom") ? " " : " --protocol $protocol "
      """
      for i in $reads
      do
@@ -722,7 +723,7 @@ process mirtrace {
      mirtrace qc \\
          --species $params.mirtrace_species \\
          $primer \\
-         --protocol $protocol \\
+         $protocol_opt $protocol \\
          --config mirtrace_config \\
          --write-fasta \\
          --output-dir mirtrace \\


### PR DESCRIPTION
A quick patch to fix the handling of --protocol (specifically custom) options when passing off to miRtrace. This fix was discussed and decided upon in [this](https://github.com/nf-core/smrnaseq/issues/41) issue.

Briefly, when working with 'custom' adapters (i.e. `--protocol custom`) the pipeline would fail. This was due to miRtrace not recognising `custom` as a valid option to `--protocol`. The proposed fix addresses this issue.